### PR TITLE
Add case for newer KDE desktops

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Script to set your Linux desktop wallpaper to the Astronomy Picture of the Day.
 ## Usage
 Invoke the script on login using a method appropriate to your desktop manager
 ```
-Usage: apod gnome1|gnome22|gnome24|gnome3|kde|fvwm|fvwm-xv|xfce|xfce4|hsetroot
+Usage: apod gnome1|gnome22|gnome24|gnome3|kde|kde4|fvwm|fvwm-xv|xfce|xfce4|hsetroot
 ```
 
 ## How it works

--- a/apod
+++ b/apod
@@ -71,6 +71,22 @@ else
             dcop kdesktop KBackgroundIface setWallpaper "" 6
             dcop kdesktop KBackgroundIface setWallpaper $imgfile 6
           ;;
+          kde4)
+          #DCOP in KDE is obsolete starting from kde4. Use qdbus
+            script='
+var Desktops = desktops();
+for (i=0;i<Desktops.length;i++) {
+        d = Desktops[i];
+        d.wallpaperPlugin = "org.kde.image";
+        d.currentConfigGroup = Array("Wallpaper",
+                                    "org.kde.image",
+                                    "General");
+        d.writeConfig("Image", "file://'
+            script+="${imgfile}"
+            script+='");
+}'
+            qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$script"
+          ;;
           "fvwm")
             #--fvwm section
             # use built-in wallpaper utility
@@ -107,7 +123,7 @@ else
             hsetroot -fill "$imgfile"
           ;;
           *)
-            echo "Usage: apod gnome1|gnome22|gnome24|gnome3|kde|fvwm|fvwm-xv|xfce|xfce4|hsetroot"
+            echo "Usage: apod gnome1|gnome22|gnome24|gnome3|kde|kde4|fvwm|fvwm-xv|xfce|xfce4|hsetroot"
           ;;
         esac
     fi


### PR DESCRIPTION
Because dcop doesn't seem to work since kde4.